### PR TITLE
Add MenuExpress CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # MenuExpress
+
+MenuExpress is a simple command-line application that lets you browse local restaurants, build custom menus, and schedule pickup or delivery orders. It demonstrates a minimal implementation of the features requested in the project description.
+
+## Features
+
+- **Browse restaurants** with search and filter options (cuisine, location and minimum rating)
+- **View menus** and add or remove dishes with quantity support
+- **Persist custom menus** and orders to JSON files
+- **Schedule orders** for delivery or pickup with date and time input
+
+## Usage
+
+1. Install Python 3 (>=3.8).
+2. Run the application:
+   ```bash
+   python -m menu_express.app
+   ```
+   The first launch creates sample restaurant data automatically.
+3. Follow the prompts to search restaurants, choose dishes and schedule an order.
+
+All data is stored in `menu_express/data/` as JSON files.

--- a/menu_express/__init__.py
+++ b/menu_express/__init__.py
@@ -1,0 +1,3 @@
+"""MenuExpress package"""
+
+__all__ = ["models", "storage", "app"]

--- a/menu_express/app.py
+++ b/menu_express/app.py
@@ -1,0 +1,113 @@
+import datetime
+from typing import List
+from .models import Dish, Restaurant, CustomMenu, Order
+from .storage import load_restaurants, save_restaurants, save_menu, save_order
+
+
+def search_restaurants(restaurants: List[Restaurant], query: str = "", cuisine: str = "", location: str = "", min_rating: float = 0.0) -> List[Restaurant]:
+    results = []
+    for r in restaurants:
+        if query and query.lower() not in r.name.lower():
+            continue
+        if cuisine and cuisine.lower() != r.cuisine.lower():
+            continue
+        if location and location.lower() not in r.location.lower():
+            continue
+        if r.rating < min_rating:
+            continue
+        results.append(r)
+    return results
+
+
+def show_restaurant(r: Restaurant):
+    print(f"\n{r.name} ({r.cuisine}) - {r.location} - Rating {r.rating}")
+    for dish in r.menu:
+        print(f"  {dish.id}. {dish.name} - ${dish.price}")
+
+
+def select_dishes(r: Restaurant) -> CustomMenu:
+    menu = CustomMenu(restaurant=r)
+    while True:
+        show_restaurant(r)
+        choice = input("Enter dish id to add (or 'done'): ").strip()
+        if choice.lower() == 'done':
+            break
+        try:
+            dish_id = int(choice)
+        except ValueError:
+            continue
+        dish = next((d for d in r.menu if d.id == dish_id), None)
+        if not dish:
+            print("Invalid dish id")
+            continue
+        qty = input("Quantity: ").strip()
+        try:
+            qty = int(qty)
+        except ValueError:
+            qty = 1
+        menu.add_item(dish, qty)
+    return menu
+
+
+def schedule_order(menu: CustomMenu) -> Order:
+    delivery_choice = input("Delivery or pickup (d/p)? ").strip().lower()
+    delivery = delivery_choice == 'd'
+    address = ''
+    if delivery:
+        address = input("Delivery address: ").strip()
+    dt_str = input("Date and time (YYYY-mm-dd HH:MM): ").strip()
+    try:
+        dt = datetime.datetime.strptime(dt_str, "%Y-%m-%d %H:%M")
+    except ValueError:
+        dt = datetime.datetime.now()
+    order = Order(menu=menu, delivery=delivery, address=address, datetime=dt.isoformat())
+    save_order(order)
+    print("Order scheduled!")
+    return order
+
+
+def main():
+    restaurants = load_restaurants()
+    if not restaurants:
+        print("No restaurants data found. Initializing sample data.")
+        from .init_data import restaurants as sample
+        save_restaurants(sample)
+        restaurants = load_restaurants()
+
+    while True:
+        query = input("Search restaurants (or leave blank): ").strip()
+        cuisine = input("Filter by cuisine (or leave blank): ").strip()
+        location = input("Filter by location (or leave blank): ").strip()
+        try:
+            rating = float(input("Minimum rating (0-5): ").strip() or 0)
+        except ValueError:
+            rating = 0
+        results = search_restaurants(restaurants, query, cuisine, location, rating)
+        if not results:
+            print("No restaurants found.")
+            continue
+        for idx, r in enumerate(results, 1):
+            print(f"{idx}. {r.name} ({r.cuisine}) - {r.location} - Rating {r.rating}")
+        sel = input("Select restaurant number (or 'q' to quit): ").strip()
+        if sel.lower() == 'q':
+            break
+        try:
+            r_idx = int(sel) - 1
+            restaurant = results[r_idx]
+        except (ValueError, IndexError):
+            print("Invalid selection")
+            continue
+        menu = select_dishes(restaurant)
+        if not menu.items:
+            print("No dishes selected.")
+            continue
+        print(f"Total price: ${menu.total_price():.2f}")
+        save_menu(menu)
+        schedule_order(menu)
+        another = input("Create another order? (y/n): ").strip().lower()
+        if another != 'y':
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/menu_express/init_data.py
+++ b/menu_express/init_data.py
@@ -1,0 +1,33 @@
+from .models import Dish, Restaurant
+from .storage import save_restaurants
+
+restaurants = [
+    Restaurant(
+        id=1,
+        name="Pasta Palace",
+        cuisine="Italian",
+        location="Downtown",
+        rating=4.5,
+        menu=[
+            Dish(id=1, name="Spaghetti Bolognese", price=12.0),
+            Dish(id=2, name="Fettuccine Alfredo", price=11.0),
+            Dish(id=3, name="Margherita Pizza", price=10.0),
+        ],
+    ),
+    Restaurant(
+        id=2,
+        name="Sushi Central",
+        cuisine="Japanese",
+        location="Uptown",
+        rating=4.7,
+        menu=[
+            Dish(id=1, name="California Roll", price=8.0),
+            Dish(id=2, name="Salmon Nigiri", price=9.5),
+            Dish(id=3, name="Tempura", price=7.0),
+        ],
+    ),
+]
+
+if __name__ == "__main__":
+    save_restaurants(restaurants)
+    print("Sample restaurants saved.")

--- a/menu_express/models.py
+++ b/menu_express/models.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass, field
+from typing import List
+
+@dataclass
+class Dish:
+    id: int
+    name: str
+    price: float
+
+@dataclass
+class Restaurant:
+    id: int
+    name: str
+    cuisine: str
+    location: str
+    rating: float
+    menu: List[Dish] = field(default_factory=list)
+
+@dataclass
+class MenuItem:
+    dish: Dish
+    quantity: int
+
+@dataclass
+class CustomMenu:
+    restaurant: Restaurant
+    items: List[MenuItem] = field(default_factory=list)
+
+    def add_item(self, dish: Dish, quantity: int = 1):
+        for item in self.items:
+            if item.dish.id == dish.id:
+                item.quantity += quantity
+                return
+        self.items.append(MenuItem(dish=dish, quantity=quantity))
+
+    def remove_item(self, dish_id: int):
+        self.items = [i for i in self.items if i.dish.id != dish_id]
+
+    def total_price(self) -> float:
+        return sum(item.dish.price * item.quantity for item in self.items)
+
+@dataclass
+class Order:
+    menu: CustomMenu
+    delivery: bool
+    address: str
+    datetime: str
+    status: str = "Pending"

--- a/menu_express/storage.py
+++ b/menu_express/storage.py
@@ -1,0 +1,75 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+from .models import Restaurant, Dish, CustomMenu, MenuItem, Order
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+DATA_DIR.mkdir(exist_ok=True)
+
+RESTAURANTS_FILE = DATA_DIR / "restaurants.json"
+MENUS_FILE = DATA_DIR / "menus.json"
+ORDERS_FILE = DATA_DIR / "orders.json"
+
+
+def load_json(path: Path, default: Any) -> Any:
+    if path.exists():
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return default
+
+
+def save_json(path: Path, data: Any) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def load_restaurants() -> List[Restaurant]:
+    data = load_json(RESTAURANTS_FILE, [])
+    restaurants = []
+    for r in data:
+        dishes = [Dish(**d) for d in r.get("menu", [])]
+        restaurants.append(Restaurant(id=r["id"], name=r["name"], cuisine=r["cuisine"],
+                                      location=r["location"], rating=r["rating"], menu=dishes))
+    return restaurants
+
+
+def save_restaurants(restaurants: List[Restaurant]) -> None:
+    data = []
+    for r in restaurants:
+        data.append({
+            "id": r.id,
+            "name": r.name,
+            "cuisine": r.cuisine,
+            "location": r.location,
+            "rating": r.rating,
+            "menu": [{"id": d.id, "name": d.name, "price": d.price} for d in r.menu]
+        })
+    save_json(RESTAURANTS_FILE, data)
+
+
+def save_menu(menu: CustomMenu) -> None:
+    data = load_json(MENUS_FILE, [])
+    entry = {
+        "restaurant": menu.restaurant.id,
+        "items": [
+            {"dish": item.dish.id, "quantity": item.quantity} for item in menu.items
+        ]
+    }
+    data.append(entry)
+    save_json(MENUS_FILE, data)
+
+
+def save_order(order: Order) -> None:
+    data = load_json(ORDERS_FILE, [])
+    entry = {
+        "restaurant": order.menu.restaurant.id,
+        "items": [
+            {"dish": item.dish.id, "quantity": item.quantity} for item in order.menu.items
+        ],
+        "delivery": order.delivery,
+        "address": order.address,
+        "datetime": order.datetime,
+        "status": order.status
+    }
+    data.append(entry)
+    save_json(ORDERS_FILE, data)


### PR DESCRIPTION
## Summary
- build simple Python CLI for MenuExpress
- add data models and storage helpers
- include sample restaurants
- document usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m menu_express.app` *(fails: EOF when reading a line because the interactive prompts were piped into a heredoc for quick launch)*

------
https://chatgpt.com/codex/tasks/task_e_686e3c3b45d083328e6577e58bb5649c